### PR TITLE
Only execute if there are classes.

### DIFF
--- a/src/main/java/io/ebean/enhance/maven/MainEnhanceMojo.java
+++ b/src/main/java/io/ebean/enhance/maven/MainEnhanceMojo.java
@@ -1,5 +1,7 @@
 package io.ebean.enhance.maven;
 
+import java.io.File;
+
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -21,7 +23,10 @@ public class MainEnhanceMojo extends AbstractEnhance {
 
 
   public void execute() throws MojoExecutionException {
-    executeFor(classSource);
+      if (new File(classSource).exists())
+          executeFor(classSource);
+      else
+          getLog().info("Skipping non-existent outputDirectory " + classSource);
   }
 
 }


### PR DESCRIPTION
This update ensures that `ebean-maven-plugin` exits gracefully when classes cannot be found. Currently, exceptions prevent this plugin from being defined and configured  in a parent POM of multiple Ebean-based projects.

While this could be resolved by defining `ebean-maven-plugin`, and by extension, `ebean-maven-tile`, under `<pluginManagement>` it would still require individual project to references them explicitly.