### PR TITLE
Fixes ebean-orm-tools/ebean-maven-plugin#20 plugin Mojos marked threadSafe

### DIFF
--- a/src/main/java/io/ebean/enhance/maven/MainEnhanceMojo.java
+++ b/src/main/java/io/ebean/enhance/maven/MainEnhanceMojo.java
@@ -9,9 +9,9 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 import java.io.File;
 
 /**
- * Enhancement for src/main classes.
+ * Enhancement for src/main classes. Marked as threadSafe to announce support for parallel building.
  */
-@Mojo(name = "enhance", defaultPhase = LifecyclePhase.PROCESS_CLASSES, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
+@Mojo(name = "enhance", defaultPhase = LifecyclePhase.PROCESS_CLASSES, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
 public class MainEnhanceMojo extends AbstractEnhance {
 
   /**

--- a/src/main/java/io/ebean/enhance/maven/TestEnhanceMojo.java
+++ b/src/main/java/io/ebean/enhance/maven/TestEnhanceMojo.java
@@ -12,7 +12,7 @@ import java.io.File;
  * Enhancement for src/main classes.
  *
  */
-@Mojo(name = "testEnhance", defaultPhase = LifecyclePhase.PROCESS_TEST_CLASSES, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
+@Mojo(name = "testEnhance", defaultPhase = LifecyclePhase.PROCESS_TEST_CLASSES, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
 public class TestEnhanceMojo extends AbstractEnhance {
 
   /**

--- a/src/main/java/io/ebean/enhance/maven/TestEnhanceMojo.java
+++ b/src/main/java/io/ebean/enhance/maven/TestEnhanceMojo.java
@@ -9,8 +9,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 import java.io.File;
 
 /**
- * Enhancement for src/main classes.
- *
+ * Enhancement for src/main classes. Marked as threadSafe to announce support for parallel building.
  */
 @Mojo(name = "testEnhance", defaultPhase = LifecyclePhase.PROCESS_TEST_CLASSES, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
 public class TestEnhanceMojo extends AbstractEnhance {


### PR DESCRIPTION
Fixes ebean-orm-tools/ebean-maven-plugin#20 with plugin Mojos "enhance" and "testEnhance" marked as threadSafe to announce support for parallel building.

Maven otherwise shows this warning when the plugin is used in parallel builds:
[WARNING] *****************************************************************
[WARNING] * Your build is requesting parallel execution, but project      *
[WARNING] * contains the following plugin(s) that have goals not marked   *
[WARNING] * as @threadSafe to support parallel building.                  *
[WARNING] * While this /may/ work fine, please look for plugin updates    *
[WARNING] * and/or request plugins be made thread-safe.                   *
[WARNING] * If reporting an issue, report it against the plugin in        *
[WARNING] * question, not against maven-core                              *
[WARNING] *****************************************************************
[WARNING] The following plugins are not marked @threadSafe in FOCONIS ZAK-Root:
[WARNING] io.ebean:ebean-maven-plugin:X.Y.Z
[WARNING] Enable debug to see more precisely which goals are not marked @threadSafe.
[WARNING] *****************************************************************